### PR TITLE
Feat(Projects) - Ability to persists order for user's projects.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,7 @@ gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 gem 'json', '~> 2.6', '>= 2.6.1'
 gem 'open-uri'
+
+gem "acts_as_list", "~> 1.0"
+
+gem "rack-cors", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts_as_list (1.0.4)
+      activerecord (>= 4.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.5.0)
@@ -120,9 +122,15 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     open-uri (0.2.0)
@@ -148,6 +156,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -257,10 +267,12 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_list (~> 1.0)
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.2)
   bootstrap (~> 4.2.1)
@@ -279,6 +291,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 4.1)
+  rack-cors (~> 1.1)
   rails (~> 6.0.4, >= 6.0.4.1)
   redis (~> 4.0)
   sass-rails (>= 6)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,19 +21,6 @@ class PagesController < ApplicationController
     end
   end
 
-  def sort
-    # old_p = params["oldPriority"]
-    new_p = params["newPriority"]
-    sorted_element_id = params["elementId"]
-    @projects = Project.where(user: current_user, completed: false)
-    @projects.each do |project|
-      if project.priority < new_p + 1
-        project.priority -= 1
-      end
-    end
-    Project.find(sorted_element_id).priority = new_p
-  end
-
   def completed_projects
     @new_project = Project.new
     search_completed_projects
@@ -60,7 +47,7 @@ class PagesController < ApplicationController
         current_user.id, params[:query], params[:query]
       )
     else
-      @projects = Project.where(user_id: current_user, completed: false).order(priority: :asc)
+      @projects = current_user.projects
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -47,7 +47,7 @@ class PagesController < ApplicationController
         current_user.id, params[:query], params[:query]
       )
     else
-      @projects = current_user.projects.where(completed: false)
+      @projects = current_user.projects
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -47,7 +47,7 @@ class PagesController < ApplicationController
         current_user.id, params[:query], params[:query]
       )
     else
-      @projects = current_user.projects
+      @projects = current_user.projects.where(completed: false)
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,11 +11,10 @@ class ProjectsController < ApplicationController
     # end
   end
 
-  # def sort
-  #   params["oldPriority"]
-  #   params["newPriority"]
-  #   params["elementId"]
-  # end
+  def sort
+    @project = Project.find(params[:id])
+    @project.insert_at(params[:position].to_i)
+  end
 
   def index
     @projects = Project.where(user: current_user)

--- a/app/javascript/controllers/persist_priority_controller.js
+++ b/app/javascript/controllers/persist_priority_controller.js
@@ -1,8 +1,25 @@
 import { Controller } from "stimulus"
+import Sortable from "sortablejs"
+import Rails from "@rails/ujs";
 
 export default class extends Controller {
   connect() {
-    console.log("Hello from persist priority controller")
+    this.sortable = Sortable.create(this.element, {
+      ghostClass: "ghost",
+      animation: 300,
+      onEnd: this.end.bind(this)
+    })
+  }
+
+  end(event){
+    let id = event.item.dataset.id;
+    let data = new FormData();
+    data.append("position", event.newIndex + 1);
+    Rails.ajax({
+      url: this.data.get("url").replace(":id", id),
+      type: 'PATCH',
+      data: data
+    })
   }
 }
 

--- a/app/javascript/plugins/init_sortable.js
+++ b/app/javascript/plugins/init_sortable.js
@@ -13,17 +13,17 @@ const initSortable = () => {
           newPriority: event.newIndex,
         }
 
-        fetch('https://example.com/profile', {
-          method: 'POST', // or 'PUT'
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(data),
-        })
-          .then(response => response.json())
-          .then(data => {
-            console.log('Success:', data);
-          })
+        // fetch('https://example.com/profile', {
+        //   method: 'POST', // or 'PUT'
+        //   headers: {
+        //     'Content-Type': 'application/json',
+        //   },
+        //   body: JSON.stringify(data),
+        // })
+        //   .then(response => response.json())
+        //   .then(data => {
+        //     console.log('Success:', data);
+        //   })
         // le voy a mandar con fetch 3 parametros a la funcion del backend, event-item.data-set.id, old-index y el new index
         // lo voy a recibir en el controlador de rails como params[], lo leo y sobre eso hago la lógica
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  acts_as_list scope: :user_id
   belongs_to :user
   has_many :timelapses, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
 
-  has_many :projects, dependent: :destroy
+  has_many :projects, -> { order(position: :asc) }, dependent: :destroy
 
   def current_user_projects
     projects = self.projects

--- a/app/views/pages/all_projects.html.erb
+++ b/app/views/pages/all_projects.html.erb
@@ -28,7 +28,7 @@
     <p>Track</p>
   </div>
 
-  <div class="sortable" data-controller="persist-priority">
+  <div class="sortable" data-controller="persist-priority" data-persist-priority-url="/projects/:id/sort">
     <% @projects.each do |project| %>
         <div data-id="<%= project.id %>" class="project-card d-flex justify-content-between align-items-center my-3" id="project-<%=project.id %>">
           <div class="card-project"><p class="margin-b"><%= link_to project.name, project_path(project) %></p></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,12 @@ module HakunaTracker
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.middleware.insert_before ActionDispatch::Static, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options, :patch]
+      end
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :projects, only: %i[create show destroy update ] do
     member do
       patch :complete
+      patch :sort
     end
     collection do
       get :clients
@@ -18,7 +19,6 @@ Rails.application.routes.draw do
   get 'pages/all_projects', to: 'pages#all_projects', as: :all_projects
   get 'projects/clients/:client', to: 'projects#client_projects', as: :client_projects
   get 'pages/completed_projects', to: 'pages#completed_projects', as: :completed_projects
-  patch 'pages/sort', to: 'pages#sort', as: :sort
   # get 'projects/invoices', to: 'projects#invoices', as: :invoices
 
 end

--- a/db/migrate/20211120225155_add_position_to_projects.rb
+++ b/db/migrate/20211120225155_add_position_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPositionToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :position, :integer
+  end
+end

--- a/db/migrate/20211120225155_add_priority_to_projects.rb
+++ b/db/migrate/20211120225155_add_priority_to_projects.rb
@@ -1,5 +1,0 @@
-class AddPriorityToProjects < ActiveRecord::Migration[6.0]
-  def change
-    add_column :projects, :priority, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2021_11_20_225155) do
     t.integer "rate"
     t.integer "cost"
     t.boolean "completed", default: false
-    t.integer "priority"
+    t.integer "position"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
## What?
Add the functionality of keeping the order of a user's projects even when moved.

## Why?
To keep the order of the user's projects.

## How?
- Adding the gem **acts_as_list**
- Adding the **patch** route to use
- Adding the controller action
- Working with **Stimulus** to create the **ajax** call to update the position of the Project.
- Adding CORS compatibility

## Anything Else?
We have a **bug** only when entering the first time to the page, it doesn't update, will look at it on saturday.